### PR TITLE
Switched Google Analytics view and changed migrate to union the two DFs

### DIFF
--- a/configVars.py
+++ b/configVars.py
@@ -32,7 +32,8 @@ CONFIG_VARS = {
 
     'GOOGLE_ANALYTICS_VIEWS': [
         {'domain': 'https://rebellion.earth',
-         'view_id': '184845394'},
+         'view_id': '220233948',
+         'old_view_id': '184845394'},
     ],
 
     'GLOBAL_INSTAGRAM_ID': '17841408183412514',
@@ -69,6 +70,11 @@ CONFIG_VARS = {
             'Cumulative Follows': 'follows_cum',
             'Cumulative Likes': 'likes_cum',
             'Cumulative Views': 'views_cum'},
+        'Website - Old': {
+            'domain': 'domain',
+            'ga:date': 'date',
+            'ga:pageviews': 'page_views',
+            'ga:sessions': 'sessions'},
         'Website': {
             'domain': 'domain',
             'ga:date': 'date',

--- a/plWebsite.py
+++ b/plWebsite.py
@@ -50,7 +50,7 @@ def extract():
                 'reportRequests': [{
                     'viewId': view['view_id'],
                     'dateRanges': [{
-                        'startDate': '2019-01-01',
+                        'startDate': '2020-06-04',
                         'endDate': 'yesterday'}],
                     'metrics': [
                         {'expression': 'ga:pageviews'},
@@ -116,7 +116,7 @@ def migrate():
     df.date = pd.to_datetime(df.date)
     df.page_views = pd.to_numeric(df.page_views)
     df.sessions = pd.to_numeric(df.sessions)
-    
+
     # Group by, to ensure there's no duplicated row from the overlap day
     df = df.groupby(['domain', 'date']).agg(
         {'page_views':'sum','sessions':'sum'}).reset_index()


### PR DESCRIPTION
When this is released, we need to:

- Make sure we have access to the Google Analytics view and it is collecting data from the website
- Make sure the old Google Analytics view is no longer collecting data from the website (and the overlap was no more than a day)
- Duplicate the Website tab of the source SS
- Rename one of them "Website - Old"
- Release and run the pipeline
- Check the target data (it should have no duplicate dates and continue seamlessly up to yesterday) 

